### PR TITLE
Fix reading `ResTable_config` structs which are shorter

### DIFF
--- a/AndroidXml/Res/ResChunk_header.cs
+++ b/AndroidXml/Res/ResChunk_header.cs
@@ -5,6 +5,18 @@ namespace AndroidXml.Res
     [Serializable]
     public class ResChunk_header
     {
+        /// <summary>
+        /// The number of bytes the <see cref="ResChunk_header"/> class occupies on disk.
+        /// </summary>
+        public static ushort DataSize
+        {
+            get
+            {
+                // Type and HeaderSize are uint16_t; size is uint32_t
+                return 8;
+            }
+        }
+
         /// Type identifier for this chunk.  The meaning of this value depends on the containing chunk.
         public ResourceType Type { get; set; }
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,8 +17,6 @@ build_script:
 on_success:
   - cmd: cd AndroidXml
   - cmd: nuget pack Package.nuspec -Prop Configuration=Release -Version %APPVEYOR_BUILD_VERSION%
-  - cmd: nuget setApiKey %NuGetApiKey% > nul
-  - cmd: nuget push AndroidXml.%APPVEYOR_BUILD_VERSION%.nupkg
   - ps: Push-AppveyorArtifact "AndroidXml.$($env:APPVEYOR_BUILD_VERSION).nupkg"
 
 nuget:


### PR DESCRIPTION
The `ResTable_config` struct has changed over time, gaining additional fields.

Old files still have old versions of this struct, so we can't be too greedy and we need to check how much data is available before reading it all.
