### PR TITLE
Be more explicit about the layout of the ResTable_config type

### DIFF
--- a/AndroidXml/AndroidXml.project.json
+++ b/AndroidXml/AndroidXml.project.json
@@ -1,6 +1,6 @@
 {
   "frameworks": {
-    "net46": {
+    "net45": {
     }
   },
 

--- a/AndroidXml/Res/ResTable_config.cs
+++ b/AndroidXml/Res/ResTable_config.cs
@@ -16,206 +16,81 @@ namespace AndroidXml.Res
     {
         // Original properties
         public uint Size { get; set; }
-        public uint IMSI { get; set; }
-        public uint Locale { get; set; }
-        public uint ScreenType { get; set; }
-        public uint Input { get; set; }
-        public uint ScreenSize { get; set; }
-        public uint Version { get; set; }
-        public uint ScreenConfig { get; set; }
-        public uint ScreenSizeDp { get; set; }
-
-        #region Derived properties
-
-        #region IMSI derived properties
-
         /// Mobile country code (from SIM). 0 means "any"
-        public ushort IMSI_MCC
-        {
-            get { return (ushort) Helper.GetBits(IMSI, 0xFFFFu, 16); }
-            set { IMSI = Helper.SetBits(IMSI, value, 0xFFFFu, 16); }
-        }
-
+        public ushort IMSI_MCC { get; set; }
         /// Mobile network code (from SIM). 0 means "any"
-        public ushort IMSI_MNC
-        {
-            get { return (ushort) Helper.GetBits(IMSI, 0xFFFFu, 0); }
-            set { IMSI = Helper.SetBits(IMSI, value, 0xFFFFu, 0); }
-        }
-
-        #endregion
-
-        #region Locale derived properties
-
-        public string LocaleLanguage
-        {
-            get
-            {
-                byte[] bytes = BitConverter.GetBytes(Locale);
-                return new string(new[] {(char) bytes[0], (char) bytes[1]});
-            }
-            set
-            {
-                if (value.Length != 2) throw new ArgumentException();
-                byte[] bytes = BitConverter.GetBytes(Locale);
-                bytes[0] = (byte) value[0];
-                bytes[1] = (byte) value[1];
-                Locale = BitConverter.ToUInt32(bytes, 0);
-            }
-        }
-
-        public string LocaleCountry
-        {
-            get
-            {
-                byte[] bytes = BitConverter.GetBytes(Locale);
-                return new string(new[] {(char) bytes[2], (char) bytes[3]});
-            }
-            set
-            {
-                if (value.Length != 2) throw new ArgumentException();
-                byte[] bytes = BitConverter.GetBytes(Locale);
-                bytes[2] = (byte) value[0];
-                bytes[3] = (byte) value[1];
-                Locale = BitConverter.ToUInt32(bytes, 0);
-            }
-        }
-
-        #endregion
-
-        #region ScreenType derived properties
-
-        public ConfigOrientation ScreenTypeOrientation
-        {
-            get { return (ConfigOrientation) Helper.GetBits(ScreenType, 0xFFu, 0); }
-            set { ScreenType = Helper.SetBits(ScreenType, (uint) value, 0xFFu, 0); }
-        }
-
-        public ConfigTouchscreen ScreenTypeTouchscreen
-        {
-            get { return (ConfigTouchscreen) Helper.GetBits(ScreenType, 0xFFu, 8); }
-            set { ScreenType = Helper.SetBits(ScreenType, (uint) value, 0xFFu, 8); }
-        }
-
-        public ConfigDensity ScreenTypeDensity
-        {
-            get { return (ConfigDensity) Helper.GetBits(ScreenType, 0xFFFFu, 16); }
-            set { ScreenType = Helper.SetBits(ScreenType, (uint) value, 0xFFFFu, 16); }
-        }
-
-        #endregion
+        public ushort IMSI_MNC { get; set; }
+        public char[] LocaleLanguage { get; set; }
+        public char[] LocaleCountry { get; set; }
+        public ConfigOrientation ScreenTypeOrientation { get; set; }
+        public ConfigTouchscreen ScreenTypeTouchscreen { get; set; }
+        public ConfigDensity ScreenTypeDensity { get; set; }
+        public ConfigKeyboard InputKeyboard { get; set; }
+        public ConfigNavigation InputNavigation { get; set; }
+        public byte InputFlags { get; set; }
+        public byte Input_Pad0 { get; set; }
+        public ushort ScreenSizeWidth { get; set; }
+        public ushort ScreenSizeHeight { get; set; }
+        public ushort VersionSdk { get; set; }
+        public ushort VersionMinor { get; set; }
+        public byte ScreenConfigScreenLayout { get; set; }
+        public byte ScreenConfigUIMode { get; set; }
+        public ushort ScreenConfigSmallestScreenWidthDp { get; set; }
+        public ushort ScreenSizeDpWidth { get; set; }
+        public ushort ScreenSizeDpHeight { get; set; }
+        public char[] LocaleScript { get; set; }
+        public char[] LocaleVariant { get; set; }
+        public byte ScreenLayout2 { get; set; }
+        public byte ScreenConfigPad1 { get; set; }
+        public ushort ScreenConfigPad2 { get; set; }
+        #region Derived properties
 
         #region Input derived properties
 
-        public ConfigKeyboard InputKeyboard
-        {
-            get { return (ConfigKeyboard) Helper.GetBits(Input, 0xFF, 24); }
-            set { Input = Helper.SetBits(Input, (uint) value, 0xFF, 24); }
-        }
-
-        public ConfigNavigation InputNavigation
-        {
-            get { return (ConfigNavigation) Helper.GetBits(Input, 0xFF, 16); }
-            set { Input = Helper.SetBits(Input, (uint) value, 0xFF, 16); }
-        }
-
         public ConfigKeysHidden InputKeysHidden
         {
-            get { return (ConfigKeysHidden) Helper.GetBits(Input, 0x3u, 8); }
-            set { Input = Helper.SetBits(Input, (uint) value, 0x3u, 8); }
+            get { return (ConfigKeysHidden)Helper.GetBits(InputFlags, (byte)0x3u, (byte)0); }
+            set { InputFlags = Helper.SetBits(InputFlags, (byte) value, (byte)0x3u, (byte)0); }
         }
 
         public ConfigNavHidden InputNavHidden
         {
-            get { return (ConfigNavHidden) Helper.GetBits(Input, 0x3u, 10); }
-            set { Input = Helper.SetBits(Input, (uint) value, 0x3u, 10); }
-        }
-
-        #endregion
-
-        #region ScreenSize derived properties
-
-        public ushort ScreenSizeWidth
-        {
-            get { return (ushort) Helper.GetBits(ScreenSize, 0xFFFFu, 16); }
-            set { ScreenSize = Helper.SetBits(ScreenSize, value, 0xFFFFu, 16); }
-        }
-
-        public ushort ScreenSizeHeight
-        {
-            get { return (ushort) Helper.GetBits(ScreenSize, 0xFFFFu, 0); }
-            set { ScreenSize = Helper.SetBits(ScreenSize, value, 0xFFFFu, 0); }
-        }
-
-        #endregion
-
-        #region Version derived properties
-
-        public ushort VersionSDK
-        {
-            get { return (ushort) Helper.GetBits(Version, 0xFFFFu, 16); }
-            set { Version = Helper.SetBits(Version, value, 0xFFFFu, 16); }
-        }
-
-        public ushort VersionMinor
-        {
-            get { return (ushort) Helper.GetBits(Version, 0xFFFFu, 0); }
-            set { Version = Helper.SetBits(Version, value, 0xFFFFu, 0); }
+            get { return (ConfigNavHidden)Helper.GetBits(InputFlags, (byte)0xc, (byte)0x2); }
+            set { InputFlags = Helper.SetBits(InputFlags, (byte)value, (byte)0xc, (byte)0x2); }
         }
 
         #endregion
 
         #region ScreenConfig derived properties
-        public ConfigScreenLayoutDirection ScreenConfigLayoutDirection
-        {
-            get { return (ConfigScreenLayoutDirection)Helper.GetBits(ScreenConfig, 0x3f, 6); }
-            set { ScreenConfig = Helper.SetBits(ScreenConfig, (uint)value, 0x3f, 6); }
-        }
 
         public ConfigScreenSize ScreenConfigScreenSize
         {
-            get { return (ConfigScreenSize) Helper.GetBits(ScreenConfig, 0x0f, 0); }
-            set { ScreenConfig = Helper.SetBits(ScreenConfig, (uint) value, 0x0f, 0); }
+            get { return (ConfigScreenSize)Helper.GetBits(ScreenConfigScreenLayout, (byte)0x0f, (byte)0); }
+            set { ScreenConfigScreenLayout = Helper.SetBits(ScreenConfigScreenLayout, (byte)value, (byte)0x0f, (byte)0); }
         }
 
         public ConfigScreenLong ScreenConfigScreenLong
         {
-            get { return (ConfigScreenLong) Helper.GetBits(ScreenConfig, 0x30, 4); }
-            set { ScreenConfig = Helper.SetBits(ScreenConfig, (uint) value, 0x30, 4); }
+            get { return (ConfigScreenLong)Helper.GetBits(ScreenConfigScreenLayout, (byte)0x30, (byte)0x04); }
+            set { ScreenConfigScreenLayout = Helper.SetBits(ScreenConfigScreenLayout, (byte)value, (byte)0x30, (byte)0x04); }
+        }
+
+        public ConfigScreenLayoutDirection ScreenConfigLayoutDirection
+        {
+            get { return (ConfigScreenLayoutDirection)Helper.GetBits(ScreenConfigScreenLayout, (byte)0xc0, (byte)0x6); }
+            set { ScreenConfigScreenLayout = Helper.SetBits(ScreenConfigScreenLayout, (byte)value, (byte)0x3f, (byte)0x6); }
         }
 
         public ConfigUIModeType ScreenConfigUIModeType
         {
-            get { return (ConfigUIModeType) Helper.GetBits(ScreenConfig, 0xFu, 16); }
-            set { ScreenConfig = Helper.SetBits(ScreenConfig, (uint) value, 0xFu, 16); }
+            get { return (ConfigUIModeType)Helper.GetBits(ScreenConfigUIMode, (byte)0x0f, (byte)0x00); }
+            set { ScreenConfigUIMode = Helper.SetBits(ScreenConfigUIMode, (byte)value, (byte)0xFu, (byte)0x00); }
         }
 
         public ConfigUIModeNight ScreenConfigUIModeNight
         {
-            get { return (ConfigUIModeNight) Helper.GetBits(ScreenConfig, 0x3u, 20); }
-            set { ScreenConfig = Helper.SetBits(ScreenConfig, (uint) value, 0x3u, 20); }
-        }
-
-        public ushort ScreenConfigSmallestScreenWidthDp
-        {
-            get { return (ushort) Helper.GetBits(ScreenConfig, 0xFFFF0000u, 16); }
-            set { ScreenConfig = Helper.SetBits(ScreenConfig, value, 0xFFFF0000u, 16); }
-        }
-
-        #endregion
-
-        #region ScreenSizeDp derived properties
-
-        public ushort ScreenSizeDpWidth
-        {
-            get { return (ushort)Helper.GetBits(ScreenSizeDp, 0xFFFFu, 0); }
-            set { ScreenSizeDp = Helper.SetBits(ScreenSizeDp, value, 0xFFFFu, 0); }
-        }
-
-        public ushort ScreenSizeDpHeight
-        {
-            get { return (ushort)Helper.GetBits(ScreenSizeDp, 0xFFFFu, 16); }
-            set { ScreenSizeDp = Helper.SetBits(ScreenSizeDp, value, 0xFFFFu, 16); }
+            get { return (ConfigUIModeNight)Helper.GetBits(ScreenConfigUIMode, (byte)0x3u, (byte)0x04); }
+            set { ScreenConfigUIMode = Helper.SetBits(ScreenConfigUIMode, (byte)value, (byte)0x3u, (byte)0x04); }
         }
 
         #endregion
@@ -225,7 +100,7 @@ namespace AndroidXml.Res
 
     #region Enums
 
-    public enum ConfigOrientation
+    public enum ConfigOrientation : byte
     {
         ORIENTATION_ANY = 0x0000,
         ORIENTATION_PORT = 0x0001,
@@ -233,7 +108,7 @@ namespace AndroidXml.Res
         ORIENTATION_SQUARE = 0x0003,
     }
 
-    public enum ConfigTouchscreen
+    public enum ConfigTouchscreen : byte
     {
         TOUCHSCREEN_ANY = 0x0000,
         TOUCHSCREEN_NOTOUCH = 0x0001,
@@ -241,7 +116,7 @@ namespace AndroidXml.Res
         TOUCHSCREEN_FINGER = 0x0003,
     }
 
-    public enum ConfigDensity
+    public enum ConfigDensity : ushort
     {
         DENSITY_DEFAULT = 0,
         DENSITY_LOW = 120,
@@ -254,7 +129,7 @@ namespace AndroidXml.Res
         DENSITY_NONE = 0xffff,
     }
 
-    public enum ConfigKeyboard
+    public enum ConfigKeyboard : byte
     {
         KEYBOARD_ANY = 0x0000,
         KEYBOARD_NOKEYS = 0x0001,
@@ -262,7 +137,7 @@ namespace AndroidXml.Res
         KEYBOARD_12KEY = 0x0003,
     }
 
-    public enum ConfigNavigation
+    public enum ConfigNavigation : byte
     {
         NAVIGATION_ANY = 0x0000,
         NAVIGATION_NONAV = 0x0001,
@@ -288,7 +163,7 @@ namespace AndroidXml.Res
 
     public enum ConfigScreenLayoutDirection
     {
-        LAYOUTDIR_ANY  = 0x00,
+        LAYOUTDIR_ANY = 0x00,
         LAYOUTDIR_LTR = 0x01,
         LAYOUTDIR_RTL = 0x02
     }

--- a/AndroidXml/ResReader.cs
+++ b/AndroidXml/ResReader.cs
@@ -71,12 +71,21 @@ namespace AndroidXml
             var value = new ResTable_config
             {
                 Size = ReadUInt32(),
-                IMSI = ReadUInt32(),
-                Locale = ReadUInt32(),
-                ScreenType = ReadUInt32(),
-                Input = ReadUInt32(),
-                ScreenSize = ReadUInt32(),
-                Version = ReadUInt32(),
+                IMSI_MCC = ReadUInt16(),
+                IMSI_MNC = ReadUInt16(),
+                LocaleLanguage = new char[] { (char)ReadByte(), (char)ReadByte() },
+                LocaleCountry = new char[] { (char)ReadByte(), (char)ReadByte() },
+                ScreenTypeOrientation = (ConfigOrientation)ReadByte(),
+                ScreenTypeTouchscreen = (ConfigTouchscreen)ReadByte(),
+                ScreenTypeDensity = (ConfigDensity)ReadUInt16(),
+                InputKeyboard = (ConfigKeyboard)ReadByte(),
+                InputNavigation = (ConfigNavigation)ReadByte(),
+                InputFlags = ReadByte(),
+                Input_Pad0 = ReadByte(),
+                ScreenSizeWidth = ReadUInt16(),
+                ScreenSizeHeight = ReadUInt16(),
+                VersionSdk = ReadUInt16(),
+                VersionMinor = ReadUInt16()
             };
 
             // Read 7 uints, which is 7 * 4 = 28 bytes worth of data. This is
@@ -88,22 +97,42 @@ namespace AndroidXml
                 return value;
             }
 
-            value.ScreenConfig = ReadUInt32();
+            value.ScreenConfigScreenLayout = ReadByte();
+            value.ScreenConfigUIMode = ReadByte();
+            value.ScreenConfigSmallestScreenWidthDp = ReadUInt16();
 
-            // And the screen size was the latest addition, so not all files may
+            // The screen size was another addition, so not all files may
             // have this value
             if (size <= 32)
             {
                 return value;
             }
 
-            value.ScreenSizeDp = ReadUInt32();
+            value.ScreenSizeDpWidth = ReadUInt16();
+            value.ScreenSizeDpHeight = ReadUInt16();
 
-            if(size > 36)
+            if (size <= 36)
+            {
+                return value;
+            }
+
+            value.LocaleScript = Encoding.ASCII.GetString(ReadBytes(4)).ToCharArray();
+            value.LocaleVariant = Encoding.ASCII.GetString(ReadBytes(8)).ToCharArray();
+
+            if (size <= 48)
+            {
+                return value;
+            }
+
+            value.ScreenLayout2 = ReadByte();
+            value.ScreenConfigPad1 = ReadByte();
+            value.ScreenConfigPad2 = ReadUInt16();
+
+            if (size > 52)
             {
                 // New fields have been added that we don't know about;
                 // padding.
-                ReadBytes((int)size - 36);
+                ReadBytes((int)size - 52);
             }
 
             return value;

--- a/AndroidXml/ResWriter.cs
+++ b/AndroidXml/ResWriter.cs
@@ -70,14 +70,38 @@ namespace AndroidXml
         public virtual void Write(ResTable_config data)
         {
             _writer.Write(data.Size);
-            _writer.Write(data.IMSI);
-            _writer.Write(data.Locale);
-            _writer.Write(data.ScreenType);
-            _writer.Write(data.Input);
-            _writer.Write(data.ScreenSize);
-            _writer.Write(data.Version);
-            _writer.Write(data.ScreenConfig);
-            _writer.Write(data.ScreenSizeDp);
+
+            _writer.Write(data.IMSI_MCC);
+            _writer.Write(data.IMSI_MNC);
+
+            _writer.Write(Encoding.ASCII.GetBytes(data.LocaleLanguage));
+            _writer.Write(Encoding.ASCII.GetBytes(data.LocaleCountry));
+
+            _writer.Write((byte)data.ScreenTypeOrientation);
+            _writer.Write((byte)data.ScreenTypeTouchscreen);
+            _writer.Write((ushort)data.ScreenTypeDensity);
+
+            _writer.Write((byte)data.InputKeyboard);
+            _writer.Write((byte)data.InputNavigation);
+            _writer.Write(data.InputFlags);
+            _writer.Write(data.Input_Pad0);
+
+            _writer.Write(data.ScreenSizeWidth);
+            _writer.Write(data.ScreenSizeHeight);
+
+            _writer.Write(data.VersionSdk);
+            _writer.Write(data.VersionMinor);
+
+            _writer.Write(data.ScreenConfigScreenLayout);
+            _writer.Write(data.ScreenConfigUIMode);
+            _writer.Write(data.ScreenConfigSmallestScreenWidthDp);
+
+            _writer.Write(Encoding.ASCII.GetBytes(data.LocaleScript));
+            _writer.Write(Encoding.ASCII.GetBytes(data.LocaleVariant));
+
+            _writer.Write(data.ScreenLayout2);
+            _writer.Write(data.ScreenConfigPad1);
+            _writer.Write(data.ScreenConfigPad2);
         }
 
         public virtual void Write(ResTable_entry data)

--- a/AndroidXml/Utils/Helper.cs
+++ b/AndroidXml/Utils/Helper.cs
@@ -19,6 +19,16 @@ namespace AndroidXml.Utils
             return (field >> shift) & mask;
         }
 
+        public static byte SetBits(byte field, byte value, byte mask, byte shift)
+        {
+            return (byte)((field & ~(mask << shift)) | ((value & mask) << shift));
+        }
+
+        public static byte GetBits(byte field, byte mask, byte shift)
+        {
+            return (byte)((field >> shift) & mask);
+        }
+
         public static uint DecodeLengthUtf8(byte[] data, ref uint position)
         {
             uint len = data[position];


### PR DESCRIPTION
Decompose union types into their individual values to:
- Avoid endianness issues.
- Allow for copy the mask and shift values directly from the C sources

Add support for the latest fields.
