### PR TITLE
Fix concurrency issue in the PublicValuesReader

### DIFF
--- a/AndroidXml.Tests/AndroidXml.Tests.csproj
+++ b/AndroidXml.Tests/AndroidXml.Tests.csproj
@@ -42,6 +42,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AndroidXmlReaderTests.cs" />
+    <Compile Include="PublicValuesReaderTests.cs" />
     <Compile Include="ResReaderTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Restable_ConfigTests.cs" />

--- a/AndroidXml.Tests/PublicValuesReaderTests.cs
+++ b/AndroidXml.Tests/PublicValuesReaderTests.cs
@@ -1,0 +1,52 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace AndroidXml.Tests
+{
+    [TestClass]
+    public class PublicValuesReaderTests
+    {
+        private static bool failed;
+
+        [TestMethod]
+        public void GetValuesConcurrencyTest()
+        {
+            // Make sure multiple threads can access the Values property in parallel.
+            Collection<Thread> threads = new Collection<Thread>();
+            for (int i = 0; i < 10; i++)
+            {
+                threads.Add(new Thread(GetValue));
+            }
+
+            foreach (var thread in threads)
+            {
+                thread.Start();
+            }
+
+            while (threads.Any(t => t.IsAlive))
+            {
+                Thread.Sleep(100);
+            }
+
+            Assert.IsFalse(failed);
+        }
+
+        private static void GetValue()
+        {
+            try
+            {
+                var value = PublicValuesReader.Values;
+            }
+            catch(Exception)
+            {
+                failed = true;
+            }
+        }
+    }
+}


### PR DESCRIPTION
If multiple threads would call `PublicValuesReader.Value` at the same time, they may all initialize the `value` field. At first, the threads would create different dictionaries, but in the end, they would all end updating the same dictionaries, causing exceptions like this one to bubble up:

```
   at System.Collections.Generic.Dictionary`2.Insert(TKey key, TValue value, Boolean add)
   at AndroidXml.PublicValuesReader.AddValue(XElement publicValue)
   at System.Collections.Generic.List`1.ForEach(Action`1 action)
   at AndroidXml.PublicValuesReader.get_Values()
   at AndroidXml.Res.ResXMLParser.GetString(Nullable`1 index)
   at AndroidXml.AndroidXmlReader.MoveToAttribute(Nullable`1 index)
   at AndroidXml.AndroidXmlReader.MoveToFirstAttribute()
```

This PR fixes that.
