### PR TITLE
Prevent accidental disposing of ResReader/ResWriter input/output streams

### DIFF
--- a/AndroidXml/ResReader.cs
+++ b/AndroidXml/ResReader.cs
@@ -16,9 +16,15 @@ namespace AndroidXml
 {
     public class ResReader : BinaryReader
     {
+        public ResReader(Stream input, Encoding encoding, bool leaveOpen)
+            : base(input, encoding, leaveOpen)
+        {
+        }
+
         public ResReader(Stream input)
             : base(input)
-        { }
+        {
+        }
 
         public virtual Res_value ReadRes_value()
         {

--- a/AndroidXml/ResWriter.cs
+++ b/AndroidXml/ResWriter.cs
@@ -14,8 +14,15 @@ namespace AndroidXml
     {
         protected readonly BinaryWriter _writer;
 
+        public ResWriter(Stream output, Encoding encoding, bool leaveOpen)
+            : this(new BinaryWriter(output, encoding, leaveOpen))
+        {
+        }
+
         public ResWriter(Stream output)
-            : this(new BinaryWriter(output)) {}
+            : this(new BinaryWriter(output))
+        {
+        }
 
         public ResWriter(BinaryWriter writer)
         {

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,12 +11,6 @@ assembly_info:
   assembly_file_version: '{version}'
   assembly_informational_version: '{version}'
 
-install:
-  - choco install -y wget
-  - wget -q https://download.microsoft.com/download/4/6/1/46116DFF-29F9-4FF8-94BF-F9BE05BE263B/packages/DotNetCore.1.0.0.RC2-SDK.Preview1-x64.exe
-  - DotNetCore.1.0.0.RC2-SDK.Preview1-x64.exe /install /quiet /log dotnetinstall.log
-  - ps: Push-AppveyorArtifact "dotnetinstall.log"
-
 build_script:
   - cmd: cd AndroidXml
   - cmd: dotnet restore


### PR DESCRIPTION
Add overloads on the ResReader and ResWriter classes, which allow you to keep the input/output stream open even after the reader/writer has been disposed of
