### PR TITLE
Enable injecting custom public values in AndroidXmlReader

### DIFF
--- a/AndroidXml/AndroidXml.csproj
+++ b/AndroidXml/AndroidXml.csproj
@@ -5,11 +5,12 @@
     <AssemblyTitle>Android XML parser for .NET</AssemblyTitle>
     <VersionPrefix>1.0.54</VersionPrefix>
     <Authors>Markus Jarderot</Authors>
-    <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">net45;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard2.0</TargetFrameworks>
     <AssemblyName>AndroidXml</AssemblyName>
     <AssemblyOriginatorKeyFile>qm.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
-    <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
+    <PublicSign>true</PublicSign>
     <PackageId>AndroidXml</PackageId>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>

--- a/AndroidXml/AndroidXmlReader.cs
+++ b/AndroidXml/AndroidXmlReader.cs
@@ -35,8 +35,23 @@ namespace AndroidXml
         #endregion
 
         public AndroidXmlReader(Stream source)
+            : this (new ResXMLParser(source))
         {
-            _parser = new ResXMLParser(source);
+        }
+
+        public AndroidXmlReader(Stream source, Stream publicValues)
+            : this(new ResXMLParser(source, publicValues))
+        {
+        }
+
+        public AndroidXmlReader(Stream source, PublicValuesReader publicValuesReader)
+            : this(new ResXMLParser(source, publicValuesReader))
+        {
+        }
+
+        public AndroidXmlReader(ResXMLParser parser)
+        {
+            _parser = parser ?? throw new ArgumentNullException(nameof(parser));
             _namespaces = new Dictionary<string, List<string>>();
             _nameTable = new NameTable();
             _readIterator = ReadIterator().GetEnumerator();


### PR DESCRIPTION
- Adds out-of-the-box support for `dotnet build` on Unix
- Adds overloads for the `AndroidXmlReader` constructor which allow you to inject a custom copy of `public.xml`.