### PR TITLE
AndroidXmlReader: Implement ReadAsync

### DIFF
--- a/AndroidXml.Tests/AndroidXmlReaderTests.cs
+++ b/AndroidXml.Tests/AndroidXmlReaderTests.cs
@@ -4,6 +4,7 @@
 // of the MIT license.  See the LICENSE file for details.
 
 using System.IO;
+using System.Threading.Tasks;
 using System.Xml.Linq;
 using Xunit;
 
@@ -20,6 +21,19 @@ namespace AndroidXml.Tests
             {
                 AndroidXmlReader reader = new AndroidXmlReader(stream);
                 reader.MoveToContent();
+                XDocument document = XDocument.Load(reader);
+            }
+        }
+
+        [Theory]
+        [InlineData("ApiDemos.AndroidManifest.xml")]
+        [InlineData("AndroidManifest2.xml")]
+        public async Task ReadManifestAsyncTest(string path)
+        {
+            using (Stream stream = File.OpenRead(path))
+            {
+                AndroidXmlReader reader = new AndroidXmlReader(stream);
+                await reader.MoveToContentAsync();
                 XDocument document = XDocument.Load(reader);
             }
         }

--- a/AndroidXml/AndroidXmlReader.cs
+++ b/AndroidXml/AndroidXmlReader.cs
@@ -11,6 +11,7 @@ using System.Linq;
 using System.Xml;
 using AndroidXml.Res;
 using System.Drawing;
+using System.Threading.Tasks;
 
 namespace AndroidXml
 {
@@ -318,6 +319,13 @@ namespace AndroidXml
         {
             _readIterator.MoveNext();
             return _readIterator.Current;
+        }
+
+        /// <inheritdoc/>
+        public override Task<bool> ReadAsync()
+        {
+            _readIterator.MoveNext();
+            return Task.FromResult(_readIterator.Current);
         }
 
         private IEnumerable<bool> ReadIterator()


### PR DESCRIPTION
The underlying code is still sync, but we avoid a NotImplementedException